### PR TITLE
Update 060.高亮查询.md

### DIFF
--- a/docs/10.v2.x文档/040.高阶语法/060.高亮查询.md
+++ b/docs/10.v2.x文档/040.高阶语法/060.高亮查询.md
@@ -63,6 +63,31 @@ public class Document{
 }
 ```
 
+:::tip 温馨提示
+如果你在多个字段上都使用了@HighLight注解并都指定了preTag和postTag,请确保每个@HighLight注解中指定的preTag和postTag是一样的,因为在查询时只会取最后一个@HighLight中指定的preTag和postTag.
+:::
+
+例如:
+```java
+public class Document{
+    /**
+     * 需要被高亮的字段1
+     */
+    @HighLight(preTag = "<span style='color:red'>", postTag = "</span>")
+    private String title;
+    /**
+     * 需要被高亮的字段2
+     */
+    @HighLight(preTag = "<span style='color:red'>", postTag = "</span>")
+    private String content;
+    /**
+     * 不需要被高亮的字段
+     */
+    private String imageUrl;
+    // 省略其它无关字段...
+}
+```
+
 :::tip 其它
 - 高亮注解支持设置高亮返回内容截取的长度fragmentSize,默认值为100
 - 高亮注解支持设置高亮内容的标签,默认为标签 em


### PR DESCRIPTION
增加了 高亮查询 中对 高亮标签使用的温馨提示和示例；

：：：tip 温馨提示
如果你在多个字段上都使用了@HighLight注解并都指定了preTag和postTag，请确保每个@HighLight注解中指定的preTag和postTag是一样的，因为在查询时只会取最后一个@HighLight中指定的preTag和postTag.
:::